### PR TITLE
Update w64devkit gcc and mingw-w64 versions.

### DIFF
--- a/web/downloads.md
+++ b/web/downloads.md
@@ -101,9 +101,9 @@ binaries directly.
             <td style="text-align:center;">
                 <strong><a href="#w64devkit">w64devkit</a></strong>
             </td>
-            <td>1.20.0</td>
+            <td>1.23.0</td>
             <td>Windows</td>
-            <td>13.2.0/11.0.0</td>
+            <td>14.1.0/11.0.1</td>
             <td>C, C++, Fortran</td>
             <td>
                 8


### PR DESCRIPTION
Upstream release: https://github.com/skeeto/w64devkit/releases/tag/v1.23.0